### PR TITLE
Add some support for AI-like chat

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,6 @@ class _ChatPageState extends State<ChatPage> {
   final _ai = const types.User(
     id: 'ASSISTANT',
   );
-  Timer? timer;
 
   @override
   void initState() {
@@ -210,16 +209,7 @@ class _ChatPageState extends State<ChatPage> {
     });
   }
 
-  void _handleSendPressed(types.PartialText message) async {
-    final textMessage = types.TextMessage(
-      author: _user,
-      createdAt: DateTime.now().millisecondsSinceEpoch,
-      id: const Uuid().v4(),
-      text: message.text,
-    );
-    _addMessage(textMessage);
-    await Future.delayed(const Duration(milliseconds: 300));
-
+  Future<void> _addAiMessage() async {
     var t = 'AI response [${_messages.length}]';
     final aiMessage = types.TextMessage(
       author: _ai,
@@ -230,30 +220,31 @@ class _ChatPageState extends State<ChatPage> {
     _addMessage(aiMessage);
     await Future.delayed(const Duration(seconds: 3));
 
-    final timer =
-        this.timer = Timer.periodic(const Duration(milliseconds: 200), (timer) {
+    final timer = Timer.periodic(const Duration(milliseconds: 200), (timer) {
       setState(() {
         t = '$t\nNew message\nNew message\nNew message\nNew message\nNew message\nNew message\nNew message';
         _messages[_messages.length - 1] = aiMessage.copyWith(text: t);
       });
-      // if (timer.isActive) {
-      //   controller.animateTo(
-      //     controller.position.maxScrollExtent,
-      //     duration: const Duration(milliseconds: 40),
-      //     curve: Curves.linear,
-      //   );
-      // }
     });
-    Future.delayed(const Duration(seconds: 3), () {
+    await Future.delayed(const Duration(seconds: 3), () {
       if (timer.isActive) {
         timer.cancel();
-        // controller.animateTo(
-        //   controller.position.maxScrollExtent,
-        //   duration: const Duration(milliseconds: 40),
-        //   curve: Curves.linear,
-        // );
       }
     });
+  }
+
+  void _handleSendPressed(types.PartialText message) async {
+    final textMessage = types.TextMessage(
+      author: _user,
+      createdAt: DateTime.now().millisecondsSinceEpoch,
+      id: const Uuid().v4(),
+      text: message.text,
+    );
+    _addMessage(textMessage);
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    await _addAiMessage();
+    await _addAiMessage();
   }
 
   void _loadMessages() async {
@@ -269,22 +260,17 @@ class _ChatPageState extends State<ChatPage> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-        body: GestureDetector(
-          onTapDown: (_) {
-            timer?.cancel();
-          },
-          child: Chat(
-            scrollController: controller,
-            messages: _messages,
-            onAttachmentPressed: _handleAttachmentPressed,
-            onMessageTap: _handleMessageTap,
-            onPreviewDataFetched: _handlePreviewDataFetched,
-            onSendPressed: _handleSendPressed,
-            showUserAvatars: true,
-            showUserNames: true,
-            user: _user,
-            mode: ChatListMode.assistant,
-          ),
+        body: Chat(
+          scrollController: controller,
+          messages: _messages,
+          onAttachmentPressed: _handleAttachmentPressed,
+          onMessageTap: _handleMessageTap,
+          onPreviewDataFetched: _handlePreviewDataFetched,
+          onSendPressed: _handleSendPressed,
+          showUserAvatars: true,
+          showUserNames: true,
+          user: _user,
+          mode: ChatListMode.assistant,
         ),
       );
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -206,26 +206,27 @@ class _ChatPageState extends State<ChatPage> {
   }
 
   void _handleSendPressed(types.PartialText message) {
-    var t = message.text;
+    final t = message.text;
     final textMessage = types.TextMessage(
       author: _user,
       createdAt: DateTime.now().millisecondsSinceEpoch,
       id: const Uuid().v4(),
       text: t,
     );
+    _addMessage(textMessage);
 
-    _streamedMessages.insert(0, textMessage);
-    final timer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
-      t = '$t New message';
-      setState(() {
-        _streamedMessages[0] = textMessage.copyWith(
-          text: t,
-        ) as types.TextMessage;
-      });
-    });
-    Future.delayed(const Duration(seconds: 3), () {
-      timer.cancel();
-    });
+    // _streamedMessages.insert(0, textMessage);
+    // final timer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
+    //   t = '$t New message';
+    //   setState(() {
+    //     _streamedMessages[0] = textMessage.copyWith(
+    //       text: t,
+    //     ) as types.TextMessage;
+    //   });
+    // });
+    // Future.delayed(const Duration(seconds: 3), () {
+    //   timer.cancel();
+    // });
   }
 
   void _loadMessages() async {
@@ -235,7 +236,7 @@ class _ChatPageState extends State<ChatPage> {
         .toList();
 
     setState(() {
-      _messages = messages;
+      _messages = messages.reversed.toList();
     });
   }
 
@@ -250,6 +251,7 @@ class _ChatPageState extends State<ChatPage> {
           showUserAvatars: true,
           showUserNames: true,
           user: _user,
+          mode: ChatListMode.assistant,
         ),
       );
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,7 +53,7 @@ class _ChatPageState extends State<ChatPage> {
 
   void _addMessage(types.Message message) {
     setState(() {
-      _messages.insert(0, message);
+      _messages.add(message);
     });
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -223,11 +223,11 @@ class _ChatPageState extends State<ChatPage> {
 
     final timer = Timer.periodic(const Duration(milliseconds: 200), (timer) {
       setState(() {
-        t = '$t\nNew message\nNew message\nNew message\nNew message\nNew message\nNew message\nNew message';
+        t = '$t\nNew message';
         _messages[_messages.length - 1] = aiMessage.copyWith(text: t);
       });
     });
-    await Future.delayed(const Duration(seconds: 3), () {
+    await Future.delayed(const Duration(seconds: 5), () {
       if (timer.isActive) {
         timer.cancel();
         setState(() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -261,6 +261,7 @@ class _ChatPageState extends State<ChatPage> {
   @override
   Widget build(BuildContext context) => Scaffold(
         body: Chat(
+          vpHeightPreferenceForAsisstant: 2 / 3,
           scrollController: controller,
           messages: _messages,
           onAttachmentPressed: _handleAttachmentPressed,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,6 +42,7 @@ class ChatPage extends StatefulWidget {
 class _ChatPageState extends State<ChatPage> {
   late final controller = AutoScrollController();
   List<types.Message> _messages = [];
+  bool _isAiTyping = false;
   final _user = const types.User(
     id: '82091008-a484-4a89-ae75-a22bf8d6f3ac',
   );
@@ -229,6 +230,9 @@ class _ChatPageState extends State<ChatPage> {
     await Future.delayed(const Duration(seconds: 3), () {
       if (timer.isActive) {
         timer.cancel();
+        setState(() {
+          _isAiTyping = false;
+        });
       }
     });
   }
@@ -240,8 +244,9 @@ class _ChatPageState extends State<ChatPage> {
       id: const Uuid().v4(),
       text: message.text,
     );
+    _isAiTyping = true;
     _addMessage(textMessage);
-    await Future.delayed(const Duration(milliseconds: 300));
+    await Future.delayed(const Duration(seconds: 3));
 
     await _addAiMessage();
     await _addAiMessage();
@@ -271,6 +276,11 @@ class _ChatPageState extends State<ChatPage> {
           showUserAvatars: true,
           showUserNames: true,
           user: _user,
+          typingIndicatorOptions: TypingIndicatorOptions(
+            typingUsers: [
+              if (_isAiTyping) _ai,
+            ],
+          ),
           mode: ChatListMode.assistant,
         ),
       );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -39,6 +40,7 @@ class ChatPage extends StatefulWidget {
 
 class _ChatPageState extends State<ChatPage> {
   List<types.Message> _messages = [];
+  final List<types.TextMessage> _streamedMessages = [];
   final _user = const types.User(
     id: '82091008-a484-4a89-ae75-a22bf8d6f3ac',
   );
@@ -204,14 +206,26 @@ class _ChatPageState extends State<ChatPage> {
   }
 
   void _handleSendPressed(types.PartialText message) {
+    var t = message.text;
     final textMessage = types.TextMessage(
       author: _user,
       createdAt: DateTime.now().millisecondsSinceEpoch,
       id: const Uuid().v4(),
-      text: message.text,
+      text: t,
     );
 
-    _addMessage(textMessage);
+    _streamedMessages.insert(0, textMessage);
+    final timer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
+      t = '$t New message';
+      setState(() {
+        _streamedMessages[0] = textMessage.copyWith(
+          text: t,
+        ) as types.TextMessage;
+      });
+    });
+    Future.delayed(const Duration(seconds: 3), () {
+      timer.cancel();
+    });
   }
 
   void _loadMessages() async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -266,7 +266,6 @@ class _ChatPageState extends State<ChatPage> {
   @override
   Widget build(BuildContext context) => Scaffold(
         body: Chat(
-          vpHeightPreferenceForAsisstant: 2 / 3,
           scrollController: controller,
           messages: _messages,
           onAttachmentPressed: _handleAttachmentPressed,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -37,7 +37,7 @@ dependencies:
   flutter_chat_types: ^3.6.2
   flutter_chat_ui:
     path: ../
-  http: '>=0.13.6 <2.0.0'
+  http: ">=0.13.6 <2.0.0"
   image_picker: ^1.1.1
   intl: ^0.19.0
   mime: ^1.0.5

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   mime: ^1.0.5
   open_filex: ^4.4.0
   path_provider: ^2.1.3
+  scroll_to_index: ^3.0.1
   uuid: ^3.0.7
 
 dev_dependencies:

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -11,7 +11,6 @@ import 'models/emoji_enlargement_behavior.dart';
 import 'models/message_spacer.dart';
 import 'models/preview_image.dart';
 import 'models/unread_header_data.dart';
-import 'widgets/chat_list.dart';
 
 /// Returns text representation of a provided bytes value (e.g. 1kB, 1GB).
 String formatBytes(int size, [int fractionDigits = 2]) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -11,6 +11,7 @@ import 'models/emoji_enlargement_behavior.dart';
 import 'models/message_spacer.dart';
 import 'models/preview_image.dart';
 import 'models/unread_header_data.dart';
+import 'widgets/chat_list.dart';
 
 /// Returns text representation of a provided bytes value (e.g. 1kB, 1GB).
 String formatBytes(int size, [int fractionDigits = 2]) {

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -105,7 +105,6 @@ class Chat extends StatefulWidget {
     this.isLeftStatus = false,
     this.messageWidthRatio = 0.72,
     this.mode = ChatListMode.conversation,
-    this.vpHeightPreferenceForAsisstant,
   });
 
   /// See [Message.audioMessageBuilder].
@@ -346,7 +345,6 @@ class Chat extends StatefulWidget {
 
   /// See [ChatListMode].
   final ChatListMode mode;
-  final double? vpHeightPreferenceForAsisstant;
 
   @override
   State<Chat> createState() => ChatState();
@@ -737,8 +735,6 @@ class ChatState extends State<Chat> {
                                         widget.typingIndicatorOptions,
                                     useTopSafeAreaInset:
                                         widget.useTopSafeAreaInset ?? isMobile,
-                                    vpHeightPreferenceForAsisstant:
-                                        widget.vpHeightPreferenceForAsisstant,
                                   ),
                                 ),
                               ),

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -475,7 +475,8 @@ class ChatState extends State<Chat> {
           Offset.zero,
           ancestor: Scrollable.of(ctx).context.findRenderObject(),
         );
-        if (offset.dy <= 0) {
+        debugPrint('offset: $offset');
+        if (offset.dy <= 100) {
           _didPutUserMsgAtTheTop = true;
           return;
         }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -104,6 +104,7 @@ class Chat extends StatefulWidget {
     this.slidableMessageBuilder,
     this.isLeftStatus = false,
     this.messageWidthRatio = 0.72,
+    this.mode = ChatListMode.conversation,
   });
 
   /// See [Message.audioMessageBuilder].
@@ -341,6 +342,9 @@ class Chat extends StatefulWidget {
 
   /// Width ratio for message bubble.
   final double messageWidthRatio;
+
+  /// See [ChatListMode].
+  final ChatListMode mode;
 
   @override
   State<Chat> createState() => ChatState();
@@ -588,7 +592,7 @@ class ChatState extends State<Chat> {
 
     if (widget.messages.isNotEmpty) {
       final result = calculateChatMessages(
-        widget.messages,
+        widget.messages.reversed.toList(),
         widget.user,
         customDateHeaderText: widget.customDateHeaderText,
         dateFormat: widget.dateFormat,
@@ -602,7 +606,7 @@ class ChatState extends State<Chat> {
         messagesSpacerHeight: widget.messagesSpacerHeight,
       );
 
-      _chatMessages = result[0] as List<Object>;
+      _chatMessages = (result[0] as List<Object>).reversed.toList();
       _gallery = result[1] as List<PreviewImage>;
 
       _refreshAutoScrollMapping();
@@ -646,6 +650,7 @@ class ChatState extends State<Chat> {
                                     BoxConstraints constraints,
                                   ) =>
                                       ChatList(
+                                    mode: widget.mode,
                                     bottomWidget: widget.listBottomWidget,
                                     bubbleRtlAlignment:
                                         widget.bubbleRtlAlignment!,

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -105,6 +105,7 @@ class Chat extends StatefulWidget {
     this.isLeftStatus = false,
     this.messageWidthRatio = 0.72,
     this.mode = ChatListMode.conversation,
+    this.vpHeightPreferenceForAsisstant,
   });
 
   /// See [Message.audioMessageBuilder].
@@ -345,6 +346,7 @@ class Chat extends StatefulWidget {
 
   /// See [ChatListMode].
   final ChatListMode mode;
+  final double? vpHeightPreferenceForAsisstant;
 
   @override
   State<Chat> createState() => ChatState();
@@ -699,6 +701,8 @@ class ChatState extends State<Chat> {
                                         widget.typingIndicatorOptions,
                                     useTopSafeAreaInset:
                                         widget.useTopSafeAreaInset ?? isMobile,
+                                    vpHeightPreferenceForAsisstant:
+                                        widget.vpHeightPreferenceForAsisstant,
                                   ),
                                 ),
                               ),

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -443,6 +443,7 @@ class ChatState extends State<Chat> {
 
   void _maybeScrollToFirstAi() {
     if (widget.mode != ChatListMode.assistant) return;
+    if (widget.messages.length < _oldMessages.length) return;
 
     final lastMessage = widget.messages.lastOrNull;
     if (lastMessage == null) return;

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -453,6 +453,9 @@ class ChatState extends State<Chat> {
     final oldLastMessage = _oldMessages.lastOrNull;
     if (oldLastMessage?.author.id == lastMessage.author.id) return;
 
+    final preferPosition = lastMessage.author.id == widget.user.id
+        ? AutoScrollPosition.end
+        : AutoScrollPosition.middle;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (mounted) {
         /// len - 1 -> spacer
@@ -460,7 +463,7 @@ class ChatState extends State<Chat> {
         await _scrollController.scrollToIndex(
           _chatMessages.length - 2,
           duration: const Duration(milliseconds: 300),
-          preferPosition: AutoScrollPosition.middle,
+          preferPosition: preferPosition,
         );
       }
     });

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -459,7 +459,7 @@ class ChatState extends State<Chat> {
         await _scrollController.scrollToIndex(
           _chatMessages.length - 2,
           duration: const Duration(milliseconds: 300),
-          preferPosition: AutoScrollPosition.begin,
+          preferPosition: AutoScrollPosition.middle,
         );
       }
     });

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -443,29 +443,19 @@ class ChatState extends State<Chat> {
 
   void _maybeScrollToFirstAi() {
     if (widget.mode != ChatListMode.assistant) return;
-    debugPrint('AAA ${widget.messages.length} << ${_oldMessages.length}');
 
     final lastMessage = widget.messages.lastOrNull;
     if (lastMessage == null) return;
-    debugPrint('Has last message');
     if (lastMessage is! types.TextMessage) return;
-    debugPrint('Last message is text message');
 
     final oldLastMessage = _oldMessages.lastOrNull;
     if (oldLastMessage is types.TextMessage &&
-        oldLastMessage.id == lastMessage.id) return;
-    debugPrint('Old last message is not the same as the last message');
+        oldLastMessage.author.id == lastMessage.author.id) return;
 
-    debugPrint(
-      'FF: ${lastMessage.id}'
-      '\nOO: ${oldLastMessage?.id}'
-      '\nPP: ${lastMessage.author.id}'
-      '\nXX: ${widget.user.id}',
-    );
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // Future.delayed(const Duration(milliseconds: 300), () async {
       if (mounted) {
-        // await Future.delayed(const Duration(milliseconds: 100));
+        /// len - 1 -> spacer
+        /// len - 2 -> last message
         await _scrollController.scrollToIndex(
           _chatMessages.length - 2,
           duration: const Duration(milliseconds: 300),

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -447,11 +447,9 @@ class ChatState extends State<Chat> {
 
     final lastMessage = widget.messages.lastOrNull;
     if (lastMessage == null) return;
-    if (lastMessage is! types.TextMessage) return;
 
     final oldLastMessage = _oldMessages.lastOrNull;
-    if (oldLastMessage is types.TextMessage &&
-        oldLastMessage.author.id == lastMessage.author.id) return;
+    if (oldLastMessage?.author.id == lastMessage.author.id) return;
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (mounted) {

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -459,7 +459,7 @@ class ChatState extends State<Chat> {
         await _scrollController.scrollToIndex(
           _chatMessages.length - 2,
           duration: const Duration(milliseconds: 300),
-          preferPosition: AutoScrollPosition.middle,
+          preferPosition: AutoScrollPosition.begin,
         );
       }
     });

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -117,10 +117,10 @@ class _ChatListState extends State<ChatList>
     didUpdateWidget(widget);
   }
 
-  void _calculateDiffs(List<Object> oldList, List<Object> newItems) async {
+  void _calculateDiffs(List<Object> oldList) async {
     final diffResult = calculateListDiff<Object>(
       oldList,
-      newItems,
+      widget.items,
       equalityChecker: (item1, item2) {
         if (item1 is Map<String, Object> && item2 is Map<String, Object>) {
           final message1 = item1['message']! as types.Message;
@@ -152,7 +152,7 @@ class _ChatListState extends State<ChatList>
 
     _scrollToBottomIfNeeded(oldList);
 
-    _oldData = List.from(newItems);
+    _oldData = List.from(widget.items);
   }
 
   Widget _newMessageBuilder(
@@ -246,7 +246,7 @@ class _ChatListState extends State<ChatList>
   void didUpdateWidget(covariant ChatList oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    _calculateDiffs(oldWidget.items, widget.items);
+    _calculateDiffs(oldWidget.items);
   }
 
   @override

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -30,7 +30,6 @@ class ChatList extends StatefulWidget {
     this.typingIndicatorOptions,
     required this.useTopSafeAreaInset,
     this.mode = ChatListMode.conversation,
-    this.vpHeightPreferenceForAsisstant,
   });
 
   /// A custom widget at the bottom of the list.
@@ -76,7 +75,6 @@ class ChatList extends StatefulWidget {
   final bool useTopSafeAreaInset;
 
   final ChatListMode mode;
-  final double? vpHeightPreferenceForAsisstant;
 
   @override
   State<ChatList> createState() => _ChatListState();

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -141,10 +141,13 @@ class _ChatListState extends State<ChatList>
     _oldData = List.from(newItems);
   }
 
-  Widget _newMessageBuilder(int index, Animation<double> animation) {
+  Widget _newMessageBuilder(
+    BuildContext context,
+    int index,
+    Animation<double> animation,
+  ) {
     try {
       final item = _oldData[index];
-
       var child = widget.itemBuilder(item, index);
       if (widget.mode == ChatListMode.assistant) {
         if (index == _oldData.length - 2) {
@@ -153,9 +156,11 @@ class _ChatListState extends State<ChatList>
             final user = InheritedUser.of(context).user;
 
             if (message.author.id != user.id) {
+              final sc = Scrollable.of(context).context.findRenderObject();
+              final minHeight = sc is RenderBox ? sc.size.height : 0.0;
               child = ConstrainedBox(
-                constraints: const BoxConstraints(
-                  minHeight: 500,
+                constraints: BoxConstraints(
+                  minHeight: minHeight,
                 ),
                 child: Align(
                   alignment: Alignment.topLeft,
@@ -315,8 +320,8 @@ class _ChatListState extends State<ChatList>
             },
             initialItemCount: widget.items.length,
             key: _listKey,
-            itemBuilder: (_, index, animation) =>
-                _newMessageBuilder(index, animation),
+            itemBuilder: (context, index, animation) =>
+                _newMessageBuilder(context, index, animation),
           ),
         ),
       ),
@@ -361,17 +366,10 @@ class _ChatListState extends State<ChatList>
       controller: widget.scrollController,
       keyboardDismissBehavior: widget.keyboardDismissBehavior,
       physics: widget.scrollPhysics,
-      center: switch (widget.mode) {
-        ChatListMode.conversation => _centerKey,
-        ChatListMode.assistant => null
-      },
+      center: _centerKey,
       reverse: switch (widget.mode) {
         ChatListMode.conversation => true,
         ChatListMode.assistant => false
-      },
-      shrinkWrap: switch (widget.mode) {
-        ChatListMode.conversation => false,
-        ChatListMode.assistant => true
       },
       slivers: widgets,
     );

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -156,46 +156,24 @@ class _ChatListState extends State<ChatList>
   }
 
   Widget _newMessageBuilder(
-    BuildContext context,
     int index,
     Animation<double> animation,
   ) {
     try {
       final item = _oldData[index];
-      var child = widget.itemBuilder(item, index);
-      if (widget.mode == ChatListMode.assistant) {
-        if (index == _oldData.length - 2) {
-          if (item is Map<String, Object>) {
-            final message = item['message']! as types.Message;
-            final user = InheritedUser.of(context).user;
-
-            if (message.author.id != user.id) {
-              const minHeight = 0.0;
-
-              child = ConstrainedBox(
-                constraints: const BoxConstraints(
-                  minHeight: minHeight,
-                ),
-                child: Align(
-                  alignment: Alignment.topLeft,
-                  child: child,
-                ),
-              );
-            }
-          }
-        }
-        return KeyedSubtree(
-          key: _valueKeyForItem(item),
-          child: child,
-        );
-      }
-
-      return SizeTransition(
-        key: _valueKeyForItem(item),
-        axisAlignment: -1,
-        sizeFactor: animation.drive(CurveTween(curve: Curves.easeOutQuad)),
-        child: child,
-      );
+      final child = widget.itemBuilder(item, index);
+      return switch (widget.mode) {
+        ChatListMode.assistant => KeyedSubtree(
+            key: _valueKeyForItem(item),
+            child: child,
+          ),
+        ChatListMode.conversation => SizeTransition(
+            key: _valueKeyForItem(item),
+            axisAlignment: -1,
+            sizeFactor: animation.drive(CurveTween(curve: Curves.easeOutQuad)),
+            child: child,
+          ),
+      };
     } catch (e) {
       return const SizedBox();
     }
@@ -332,8 +310,8 @@ class _ChatListState extends State<ChatList>
           },
           initialItemCount: widget.items.length,
           key: _listKey,
-          itemBuilder: (context, index, animation) =>
-              _newMessageBuilder(context, index, animation),
+          itemBuilder: (_, index, animation) =>
+              _newMessageBuilder(index, animation),
         ),
       ),
     );

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -159,17 +159,10 @@ class _ChatListState extends State<ChatList>
             final user = InheritedUser.of(context).user;
 
             if (message.author.id != user.id) {
-              var minHeight = 0.0;
-              if (widget.vpHeightPreferenceForAsisstant != null) {
-                final sc = _listKey.currentContext?.findRenderObject();
-                if (sc is RenderSliverList) {
-                  minHeight = sc.constraints.viewportMainAxisExtent *
-                      widget.vpHeightPreferenceForAsisstant!;
-                }
-              }
+              const minHeight = 0.0;
 
               child = ConstrainedBox(
-                constraints: BoxConstraints(
+                constraints: const BoxConstraints(
                   minHeight: minHeight,
                 ),
                 child: Align(

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -159,7 +159,7 @@ class _ChatListState extends State<ChatList>
             if (message.author.id != user.id) {
               final sc = _listKey.currentContext?.findRenderObject();
               final minHeight = sc is RenderSliverList
-                  ? (sc.constraints.viewportMainAxisExtent / 3 * 2)
+                  ? sc.constraints.viewportMainAxisExtent / 3
                   : 0.0;
               child = ConstrainedBox(
                 constraints: BoxConstraints(

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -362,27 +362,27 @@ class _ChatListState extends State<ChatList>
       },
       slivers: widgets,
     );
-    child = NotificationListener<ScrollMetricsNotification>(
-      onNotification: (n) {
-        final metrics = n.metrics;
-        if (!_didLoadView && metrics.extentAfter == metrics.maxScrollExtent) {
-          WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-            widget.scrollController.animateTo(
-              widget.scrollController.position.maxScrollExtent,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeOutQuad,
-            );
-            Future.delayed(const Duration(milliseconds: 100), () {
-              setState(() {
-                _didLoadView = true;
-              });
+
+    /// Scroll to the bottom of the list when the view is first loaded.
+    if (widget.mode == ChatListMode.assistant) {
+      child = NotificationListener<ScrollMetricsNotification>(
+        onNotification: (notification) {
+          final metrics = notification.metrics;
+          if (!_didLoadView && metrics.extentAfter == metrics.maxScrollExtent) {
+            WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+              widget.scrollController.animateTo(
+                widget.scrollController.position.maxScrollExtent,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeOutQuad,
+              );
+              _didLoadView = true;
             });
-          });
-        }
-        return true;
-      },
-      child: child,
-    );
+          }
+          return true;
+        },
+        child: child,
+      );
+    }
     return NotificationListener<ScrollNotification>(
       onNotification: (notification) {
         if (notification.metrics.pixels > 10.0 && !_indicatorOnScrollStatus) {

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:diffutil_dart/diffutil.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 
 import '../models/bubble_rtl_alignment.dart';
@@ -85,19 +88,20 @@ class _ChatListState extends State<ChatList>
   bool _isNextPageLoading = false;
   final GlobalKey<SliverAnimatedListState> _listKey =
       GlobalKey<SliverAnimatedListState>();
+
+  final GlobalKey _centerKey = GlobalKey();
   late List<Object> _oldData = List.from(widget.items);
 
   @override
   void initState() {
     super.initState();
-
     didUpdateWidget(widget);
   }
 
-  void _calculateDiffs(List<Object> oldList) async {
+  void _calculateDiffs(List<Object> oldList, List<Object> newItems) async {
     final diffResult = calculateListDiff<Object>(
       oldList,
-      widget.items,
+      newItems,
       equalityChecker: (item1, item2) {
         if (item1 is Map<String, Object> && item2 is Map<String, Object>) {
           final message1 = item1['message']! as types.Message;
@@ -129,7 +133,7 @@ class _ChatListState extends State<ChatList>
 
     _scrollToBottomIfNeeded(oldList);
 
-    _oldData = List.from(widget.items);
+    _oldData = List.from(newItems);
   }
 
   Widget _newMessageBuilder(int index, Animation<double> animation) {
@@ -206,7 +210,7 @@ class _ChatListState extends State<ChatList>
   void didUpdateWidget(covariant ChatList oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    _calculateDiffs(oldWidget.items);
+    _calculateDiffs(oldWidget.items, widget.items);
   }
 
   @override
@@ -264,6 +268,7 @@ class _ChatListState extends State<ChatList>
           controller: widget.scrollController,
           keyboardDismissBehavior: widget.keyboardDismissBehavior,
           physics: widget.scrollPhysics,
+          center: _centerKey,
           reverse: true,
           slivers: [
             if (widget.bottomWidget != null)
@@ -296,6 +301,7 @@ class _ChatListState extends State<ChatList>
               ),
             ),
             SliverPadding(
+              key: _centerKey,
               padding: InheritedChatTheme.of(context).theme.chatContentMargin,
               sliver: SliverAnimatedList(
                 findChildIndexCallback: (Key key) {

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:diffutil_dart/diffutil.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 
 import '../models/bubble_rtl_alignment.dart';
@@ -156,8 +157,10 @@ class _ChatListState extends State<ChatList>
             final user = InheritedUser.of(context).user;
 
             if (message.author.id != user.id) {
-              final sc = Scrollable.of(context).context.findRenderObject();
-              final minHeight = sc is RenderBox ? sc.size.height : 0.0;
+              final sc = _listKey.currentContext?.findRenderObject();
+              final minHeight = sc is RenderSliverList
+                  ? (sc.constraints.viewportMainAxisExtent / 3 * 2)
+                  : 0.0;
               child = ConstrainedBox(
                 constraints: BoxConstraints(
                   minHeight: minHeight,

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -30,6 +30,7 @@ class ChatList extends StatefulWidget {
     this.typingIndicatorOptions,
     required this.useTopSafeAreaInset,
     this.mode = ChatListMode.conversation,
+    this.vpHeightPreferenceForAsisstant,
   });
 
   /// A custom widget at the bottom of the list.
@@ -75,6 +76,7 @@ class ChatList extends StatefulWidget {
   final bool useTopSafeAreaInset;
 
   final ChatListMode mode;
+  final double? vpHeightPreferenceForAsisstant;
 
   @override
   State<ChatList> createState() => _ChatListState();
@@ -157,10 +159,15 @@ class _ChatListState extends State<ChatList>
             final user = InheritedUser.of(context).user;
 
             if (message.author.id != user.id) {
-              final sc = _listKey.currentContext?.findRenderObject();
-              final minHeight = sc is RenderSliverList
-                  ? sc.constraints.viewportMainAxisExtent / 3
-                  : 0.0;
+              var minHeight = 0.0;
+              if (widget.vpHeightPreferenceForAsisstant != null) {
+                final sc = _listKey.currentContext?.findRenderObject();
+                if (sc is RenderSliverList) {
+                  minHeight = sc.constraints.viewportMainAxisExtent *
+                      widget.vpHeightPreferenceForAsisstant!;
+                }
+              }
+
               child = ConstrainedBox(
                 constraints: BoxConstraints(
                   minHeight: minHeight,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://flyer.chat
 repository: https://github.com/flyerhq/flutter_chat_ui
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   flutter: '>=3.0.0'
 
 dependencies:


### PR DESCRIPTION
Overview of the changes:
1. Update pub so that it can be run on our setup
2. Update example with a mock assistant <-> user interop
3. Add `ChatListMode`: 
  1. In `chat_list.dart` now scroll view is not reversed in `assistant` mode and instead adds messages to the actual bottom making new content invisible until scrolled.
  2. In `chat.dart` there is a new handler that auto-scrolls in a specific manner so that the new content becomes automatically visible but not until the last User's message is out of bounds. Basically a merge of behaviour between `Claud/Gemini` and `ChatGPT`